### PR TITLE
fixed a runtime error when using the IL2CPP scripting backend

### DIFF
--- a/Assets/uDesktopDuplication/Scripts/Manager.cs
+++ b/Assets/uDesktopDuplication/Scripts/Manager.cs
@@ -62,8 +62,13 @@ public class Manager : MonoBehaviour
     private float reinitializationTimer_ = 0f;
     private bool isFirstFrame_ = true;
 
-    public static event Lib.DebugLogDelegate onDebugLog = msg => Debug.Log(msg);
-    public static event Lib.DebugLogDelegate onDebugErr = msg => Debug.LogError(msg);
+    public static event Lib.DebugLogDelegate onDebugLog = OnDebugLog;
+    public static event Lib.DebugLogDelegate onDebugErr = OnDebugErr;
+
+    [AOT.MonoPInvokeCallback(typeof(Lib.DebugLogDelegate))]
+    private static void OnDebugLog(string msg) { Debug.Log(msg); }
+    [AOT.MonoPInvokeCallback(typeof(Lib.DebugLogDelegate))]
+    private static void OnDebugErr(string msg) { Debug.LogError(msg); }
 
     public delegate void ReinitializeHandler();
     public static event ReinitializeHandler onReinitialized;


### PR DESCRIPTION
Hi hecomi.

I found a runtime error when using the IL2CPP scripting backend with Unity 2018.2.7f1.

```
NotSupportedException: To marshal a managed method, please add an attribute named 'MonoPInvokeCallback' to the method definition.
```

So I fixed it according to the error message.
Could you check this pull request?